### PR TITLE
implement tsinfo messages for retrieving timestamping capabilities

### DIFF
--- a/examples/dump_tsinfo.rs
+++ b/examples/dump_tsinfo.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+
+// Once we find a way to load netsimdev kernel module in CI, we can convert this
+// to a test
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let iface_name = std::env::args().nth(1);
+    rt.block_on(get_tsinfo(iface_name.as_deref()));
+}
+
+async fn get_tsinfo(iface_name: Option<&str>) {
+    let (connection, mut handle, _) = ethtool::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut tsinfo_handle = handle.tsinfo().get(iface_name).execute().await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = tsinfo_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(!msgs.is_empty());
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/bitset_util.rs
+++ b/src/bitset_util.rs
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use log::warn;
+use netlink_packet_utils::{
+    nla::NlasIterator, parsers::parse_string, DecodeError,
+};
+
+const ETHTOOL_A_BITSET_BITS: u16 = 3;
+
+const ETHTOOL_A_BITSET_BITS_BIT: u16 = 1;
+
+const ETHTOOL_A_BITSET_BIT_INDEX: u16 = 1;
+const ETHTOOL_A_BITSET_BIT_NAME: u16 = 2;
+const ETHTOOL_A_BITSET_BIT_VALUE: u16 = 3;
+
+pub(crate) fn parse_bitset_bits_nlas(
+    raw: &[u8],
+) -> Result<Vec<String>, DecodeError> {
+    let error_msg = "failed to parse mode bit sets";
+    for nla in NlasIterator::new(raw) {
+        let nla = &nla.context(error_msg)?;
+        if nla.kind() == ETHTOOL_A_BITSET_BITS {
+            return parse_bitset_bits_nla(nla.value());
+        }
+    }
+    Err("No ETHTOOL_A_BITSET_BITS NLA found".into())
+}
+
+fn parse_bitset_bits_nla(raw: &[u8]) -> Result<Vec<String>, DecodeError> {
+    let mut modes = Vec::new();
+    let error_msg = "Failed to parse ETHTOOL_A_BITSET_BITS attributes";
+    for bit_nla in NlasIterator::new(raw) {
+        let bit_nla = &bit_nla.context(error_msg)?;
+        match bit_nla.kind() {
+            ETHTOOL_A_BITSET_BITS_BIT => {
+                let error_msg =
+                    "Failed to parse ETHTOOL_A_BITSET_BITS_BIT attributes";
+                let nlas = NlasIterator::new(bit_nla.value());
+                for nla in nlas {
+                    let nla = &nla.context(error_msg)?;
+                    let payload = nla.value();
+                    match nla.kind() {
+                        ETHTOOL_A_BITSET_BIT_INDEX
+                        | ETHTOOL_A_BITSET_BIT_VALUE => {
+                            // ignored
+                        }
+                        ETHTOOL_A_BITSET_BIT_NAME => {
+                            modes.push(parse_string(payload).context(
+                                "Invald ETHTOOL_A_BITSET_BIT_NAME value",
+                            )?);
+                        }
+                        _ => {
+                            warn!(
+                                "Unknown ETHTOOL_A_BITSET_BITS_BIT {} {:?}",
+                                nla.kind(),
+                                nla.value(),
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {
+                warn!(
+                    "Unknown ETHTOOL_A_BITSET_BITS kind {}, {:?}",
+                    bit_nla.kind(),
+                    bit_nla.value()
+                );
+            }
+        };
+    }
+    Ok(modes)
+}

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -11,7 +11,7 @@ use netlink_packet_utils::DecodeError;
 use crate::{
     try_ethtool, EthtoolCoalesceHandle, EthtoolError, EthtoolFeatureHandle,
     EthtoolLinkModeHandle, EthtoolMessage, EthtoolPauseHandle,
-    EthtoolRingHandle,
+    EthtoolRingHandle, EthtoolTsInfoHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -42,6 +42,10 @@ impl EthtoolHandle {
 
     pub fn coalesce(&mut self) -> EthtoolCoalesceHandle {
         EthtoolCoalesceHandle::new(self.clone())
+    }
+
+    pub fn tsinfo(&mut self) -> EthtoolTsInfoHandle {
+        EthtoolTsInfoHandle::new(self.clone())
     }
 
     pub async fn request(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 
+mod bitset_util;
 mod coalesce;
 mod connection;
 mod error;
@@ -11,6 +12,7 @@ mod macros;
 mod message;
 mod pause;
 mod ring;
+mod tsinfo;
 
 pub use coalesce::{
     EthtoolCoalesceAttr, EthtoolCoalesceGetRequest, EthtoolCoalesceHandle,
@@ -35,5 +37,8 @@ pub use pause::{
     EthtoolPauseStatAttr,
 };
 pub use ring::{EthtoolRingAttr, EthtoolRingGetRequest, EthtoolRingHandle};
+pub use tsinfo::{
+    EthtoolTsInfoAttr, EthtoolTsInfoGetRequest, EthtoolTsInfoHandle,
+};
 
 pub(crate) use handle::ethtool_execute;

--- a/src/message.rs
+++ b/src/message.rs
@@ -11,6 +11,7 @@ use crate::{
     link_mode::{parse_link_mode_nlas, EthtoolLinkModeAttr},
     pause::{parse_pause_nlas, EthtoolPauseAttr},
     ring::{parse_ring_nlas, EthtoolRingAttr},
+    tsinfo::{parse_tsinfo_nlas, EthtoolTsInfoAttr},
     EthtoolHeader,
 };
 
@@ -24,6 +25,8 @@ const ETHTOOL_MSG_RINGS_GET: u8 = 15;
 const ETHTOOL_MSG_RINGS_GET_REPLY: u8 = 16;
 const ETHTOOL_MSG_COALESCE_GET: u8 = 19;
 const ETHTOOL_MSG_COALESCE_GET_REPLY: u8 = 20;
+const ETHTOOL_MSG_TSINFO_GET: u8 = 25;
+const ETHTOOL_MSG_TSINFO_GET_REPLY: u8 = 26;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum EthtoolCmd {
@@ -37,6 +40,8 @@ pub enum EthtoolCmd {
     RingGetReply,
     CoalesceGet,
     CoalesceGetReply,
+    TsInfoGet,
+    TsInfoGetReply,
 }
 
 impl From<EthtoolCmd> for u8 {
@@ -52,6 +57,8 @@ impl From<EthtoolCmd> for u8 {
             EthtoolCmd::RingGetReply => ETHTOOL_MSG_RINGS_GET_REPLY,
             EthtoolCmd::CoalesceGet => ETHTOOL_MSG_COALESCE_GET,
             EthtoolCmd::CoalesceGetReply => ETHTOOL_MSG_COALESCE_GET_REPLY,
+            EthtoolCmd::TsInfoGet => ETHTOOL_MSG_TSINFO_GET,
+            EthtoolCmd::TsInfoGetReply => ETHTOOL_MSG_TSINFO_GET_REPLY,
         }
     }
 }
@@ -63,6 +70,7 @@ pub enum EthtoolAttr {
     LinkMode(EthtoolLinkModeAttr),
     Ring(EthtoolRingAttr),
     Coalesce(EthtoolCoalesceAttr),
+    TsInfo(EthtoolTsInfoAttr),
 }
 
 impl Nla for EthtoolAttr {
@@ -73,6 +81,7 @@ impl Nla for EthtoolAttr {
             Self::LinkMode(attr) => attr.value_len(),
             Self::Ring(attr) => attr.value_len(),
             Self::Coalesce(attr) => attr.value_len(),
+            Self::TsInfo(attr) => attr.value_len(),
         }
     }
 
@@ -83,6 +92,7 @@ impl Nla for EthtoolAttr {
             Self::LinkMode(attr) => attr.kind(),
             Self::Ring(attr) => attr.kind(),
             Self::Coalesce(attr) => attr.kind(),
+            Self::TsInfo(attr) => attr.kind(),
         }
     }
 
@@ -93,6 +103,7 @@ impl Nla for EthtoolAttr {
             Self::LinkMode(attr) => attr.emit_value(buffer),
             Self::Ring(attr) => attr.emit_value(buffer),
             Self::Coalesce(attr) => attr.emit_value(buffer),
+            Self::TsInfo(attr) => attr.emit_value(buffer),
         }
     }
 }
@@ -196,6 +207,23 @@ impl EthtoolMessage {
             nlas,
         }
     }
+
+    pub fn new_tsinfo_get(iface_name: Option<&str>) -> Self {
+        let nlas = match iface_name {
+            Some(s) => {
+                vec![EthtoolAttr::TsInfo(EthtoolTsInfoAttr::Header(vec![
+                    EthtoolHeader::DevName(s.to_string()),
+                ]))]
+            }
+            None => {
+                vec![EthtoolAttr::TsInfo(EthtoolTsInfoAttr::Header(vec![]))]
+            }
+        };
+        EthtoolMessage {
+            cmd: EthtoolCmd::TsInfoGet,
+            nlas,
+        }
+    }
 }
 
 impl Emitable for EthtoolMessage {
@@ -233,6 +261,10 @@ impl ParseableParametrized<[u8], GenlHeader> for EthtoolMessage {
             ETHTOOL_MSG_COALESCE_GET_REPLY => Self {
                 cmd: EthtoolCmd::CoalesceGetReply,
                 nlas: parse_coalesce_nlas(buffer)?,
+            },
+            ETHTOOL_MSG_TSINFO_GET_REPLY => Self {
+                cmd: EthtoolCmd::TsInfoGetReply,
+                nlas: parse_tsinfo_nlas(buffer)?,
             },
             cmd => {
                 return Err(DecodeError::from(format!(

--- a/src/tsinfo/attr.rs
+++ b/src/tsinfo/attr.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    parsers::parse_u32,
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::{bitset_util::parse_bitset_bits_nlas, EthtoolAttr, EthtoolHeader};
+
+const ETHTOOL_A_TSINFO_HEADER: u16 = 1;
+const ETHTOOL_A_TSINFO_TIMESTAMPING: u16 = 2;
+const ETHTOOL_A_TSINFO_TX_TYPES: u16 = 3;
+const ETHTOOL_A_TSINFO_RX_FILTERS: u16 = 4;
+const ETHTOOL_A_TSINFO_PHC_INDEX: u16 = 5;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolTsInfoAttr {
+    Header(Vec<EthtoolHeader>),
+    Timestamping(Vec<String>),
+    TxTypes(Vec<String>),
+    RxFilters(Vec<String>),
+    PhcIndex(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolTsInfoAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::Timestamping(_)
+            | Self::PhcIndex(_)
+            | Self::TxTypes(_)
+            | Self::RxFilters(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_TSINFO_HEADER | NLA_F_NESTED,
+            Self::Timestamping(_) => ETHTOOL_A_TSINFO_TIMESTAMPING,
+            Self::TxTypes(_) => ETHTOOL_A_TSINFO_TX_TYPES,
+            Self::RxFilters(_) => ETHTOOL_A_TSINFO_RX_FILTERS,
+            Self::PhcIndex(_) => ETHTOOL_A_TSINFO_PHC_INDEX,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Other(ref attr) => attr.emit(buffer),
+            _ => todo!("Does not support changing ethtool ts info yet"),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolTsInfoAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_TSINFO_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse link_mode header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_TSINFO_TIMESTAMPING => Self::Timestamping(
+                parse_bitset_bits_nlas(payload)
+                    .context("Invalid ETHTOOL_A_TSINFO_TIMESTAMPING value")?,
+            ),
+            ETHTOOL_A_TSINFO_TX_TYPES => Self::TxTypes(
+                parse_bitset_bits_nlas(payload)
+                    .context("Invalid ETHTOOL_A_TSINFO_TX_TYPES value")?,
+            ),
+            ETHTOOL_A_TSINFO_RX_FILTERS => Self::RxFilters(
+                parse_bitset_bits_nlas(payload)
+                    .context("Invalid ETHTOOL_A_TSINFO_RX_FILTERS value")?,
+            ),
+            ETHTOOL_A_TSINFO_PHC_INDEX => Self::PhcIndex(
+                parse_u32(payload)
+                    .context("Invalid ETHTOOL_A_TSINFO_PHC_INDEX value")?,
+            ),
+            _ => Self::Other(
+                DefaultNla::parse(buf).context("invalid NLA (unknown kind)")?,
+            ),
+        })
+    }
+}
+
+pub(crate) fn parse_tsinfo_nlas(
+    buffer: &[u8],
+) -> Result<Vec<EthtoolAttr>, DecodeError> {
+    let mut nlas = Vec::new();
+    for nla in NlasIterator::new(buffer) {
+        let error_msg = format!(
+            "Failed to parse ethtool tsinfo message attribute {:?}",
+            nla
+        );
+        let nla = &nla.context(error_msg.clone())?;
+        let parsed = EthtoolTsInfoAttr::parse(nla).context(error_msg)?;
+        nlas.push(EthtoolAttr::TsInfo(parsed));
+    }
+    Ok(nlas)
+}

--- a/src/tsinfo/get.rs
+++ b/src/tsinfo/get.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_generic::GenlMessage;
+
+use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct EthtoolTsInfoGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+}
+
+impl EthtoolTsInfoGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>) -> Self {
+        EthtoolTsInfoGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+        }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<EthtoolMessage>, Error = EthtoolError>
+    {
+        let EthtoolTsInfoGetRequest {
+            mut handle,
+            iface_name,
+        } = self;
+
+        let ethtool_msg = EthtoolMessage::new_tsinfo_get(iface_name.as_deref());
+        ethtool_execute(&mut handle, iface_name.is_none(), ethtool_msg).await
+    }
+}

--- a/src/tsinfo/handle.rs
+++ b/src/tsinfo/handle.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{EthtoolHandle, EthtoolTsInfoGetRequest};
+
+pub struct EthtoolTsInfoHandle(EthtoolHandle);
+
+impl EthtoolTsInfoHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        EthtoolTsInfoHandle(handle)
+    }
+
+    /// Retrieve the ethtool timestamping capabilities of an interface
+    pub fn get(&mut self, iface_name: Option<&str>) -> EthtoolTsInfoGetRequest {
+        EthtoolTsInfoGetRequest::new(self.0.clone(), iface_name)
+    }
+}

--- a/src/tsinfo/mod.rs
+++ b/src/tsinfo/mod.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+mod attr;
+mod get;
+mod handle;
+
+pub(crate) use attr::parse_tsinfo_nlas;
+pub use attr::EthtoolTsInfoAttr;
+pub use get::EthtoolTsInfoGetRequest;
+pub use handle::EthtoolTsInfoHandle;


### PR DESCRIPTION
Equivalent to `ethtool -T` command.

Add [tsinfo](https://github.com/torvalds/linux/blob/8bb7eca972ad531c9b149c0a51ab43a417385813/include/uapi/linux/ethtool_netlink.h#L432) messages for retrieving timestamping capabilites of network interfaces. Basically a copycat operation from `link_mode` :)

Extract bitset parsing utils to a separate module `bitset_util` (as they are now used by `link_mode` and `tsinfo` modules) and add a network interface filter to the example (i can remove this or add to the other examples as well?).
