### PR TITLE
New release 0.2.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+# Changelog
+## [0.2.4] - 2023-01-29
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (151f217)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethtool"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (151f217)