### PR TITLE
New release 0.2.5

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.2.5] - 2023-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - Support time stamp (`ethtool --show-time-stamping`). (b753d74)
+
+### Bug fixes
+ - Use latest rust-netlink crates. (615b168)
+
 ## [0.2.4] - 2023-01-29
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethtool"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2018"


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - Support time stamp (`ethtool --show-time-stamping`). (b753d74)

=== Bug fixes
 - Use latest rust-netlink crates. (615b168)