### PR TITLE
Adding support for dumping eeprom pages.

### DIFF
--- a/examples/dump_eeprom_page.rs
+++ b/examples/dump_eeprom_page.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+use futures::stream::TryStreamExt;
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap();
+    let iface_name = std::env::args().nth(1);
+    rt.block_on(get_eeprom(iface_name.as_deref()));
+}
+
+async fn get_eeprom(iface_name: Option<&str>) {
+    let (connection, mut handle, _) = ethtool::new_connection().unwrap();
+    tokio::spawn(connection);
+
+    let mut eeprom_handle = handle
+        .eeprom()
+        .get(iface_name, 0, 1, 0, 0, 0x50)
+        .execute()
+        .await;
+
+    let mut msgs = Vec::new();
+    while let Some(msg) = eeprom_handle.try_next().await.unwrap() {
+        msgs.push(msg);
+    }
+    assert!(!msgs.is_empty());
+    for msg in msgs {
+        println!("{:?}", msg);
+    }
+}

--- a/src/eeprom/attr.rs
+++ b/src/eeprom/attr.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian};
+use netlink_packet_utils::{
+    nla::{DefaultNla, Nla, NlaBuffer, NlasIterator, NLA_F_NESTED},
+    DecodeError, Emitable, Parseable,
+};
+
+use crate::{EthtoolAttr, EthtoolHeader};
+
+
+const ETHTOOL_A_MODULE_EEPROM_HEADER: u16 = 1;
+const ETHTOOL_A_MODULE_EEPROM_OFFSET: u16 = 2;
+const ETHTOOL_A_MODULE_EEPROM_LENGTH: u16 = 3;
+const ETHTOOL_A_MODULE_EEPROM_PAGE: u16 = 4;
+const ETHTOOL_A_MODULE_EEPROM_BANK: u16 = 5;
+const ETHTOOL_A_MODULE_EEPROM_I2C_ADDRESS: u16 = 6;
+const ETHTOOL_A_MODULE_EEPROM_DATA: u16 = 7;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolModuleEEPROMAttr {
+    Header(Vec<EthtoolHeader>),
+    Offset(u32),
+    Length(u32),
+    Page(u8),
+    Bank(u8),
+    I2CAddress(u8),
+    Data(Vec<u8>),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolModuleEEPROMAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(hdrs) => hdrs.as_slice().buffer_len(),
+            Self::Data(data) => data.len(),
+            Self::Page(_)
+            | Self::Bank(_)
+            | Self::I2CAddress(_) => 1,
+            Self::Offset(_)
+            | Self::Length(_) => 4,
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_MODULE_EEPROM_HEADER | NLA_F_NESTED,
+            Self::Offset(_) => ETHTOOL_A_MODULE_EEPROM_OFFSET,
+            Self::Length(_) => ETHTOOL_A_MODULE_EEPROM_LENGTH,
+            Self::Page(_) => ETHTOOL_A_MODULE_EEPROM_PAGE,
+            Self::Bank(_) => ETHTOOL_A_MODULE_EEPROM_BANK,
+            Self::I2CAddress(_) => ETHTOOL_A_MODULE_EEPROM_I2C_ADDRESS,
+            Self::Data(_) => ETHTOOL_A_MODULE_EEPROM_DATA,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(ref nlas) => nlas.as_slice().emit(buffer),
+            Self::Data(d) => buffer.copy_from_slice(d.as_slice()),
+            Self::Page(d)
+            | Self::Bank(d)
+            | Self::I2CAddress(d) => buffer[0] = *d,
+            Self::Offset(d)
+            | Self::Length(d) => NativeEndian::write_u32(buffer, *d),
+            Self::Other(ref attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolModuleEEPROMAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            ETHTOOL_A_MODULE_EEPROM_HEADER => {
+                let mut nlas = Vec::new();
+                let error_msg = "failed to parse module eeprom header attributes";
+                for nla in NlasIterator::new(payload) {
+                    let nla = &nla.context(error_msg)?;
+                    let parsed =
+                        EthtoolHeader::parse(nla).context(error_msg)?;
+                    nlas.push(parsed);
+                }
+                Self::Header(nlas)
+            }
+            ETHTOOL_A_MODULE_EEPROM_DATA => Self::Data(
+                Vec::from(payload),
+            ),
+            kind => Self::Other(
+                DefaultNla::parse(buf)
+                    .context(format!("invalid ethtool module eeprom NLA kind {kind}"))?,
+            ),
+        })
+    }
+}
+
+pub(crate) fn parse_module_eeprom_nlas(
+    buffer: &[u8],
+) -> Result<Vec<EthtoolAttr>, DecodeError> {
+    let mut nlas = Vec::new();
+    for nla in NlasIterator::new(buffer) {
+        let error_msg =
+            format!("Failed to parse ethtool module eeprom message attribute {nla:?}");
+        let nla = &nla.context(error_msg.clone())?;
+        let parsed = EthtoolModuleEEPROMAttr::parse(nla).context(error_msg)?;
+        nlas.push(EthtoolAttr::ModuleEEPROM(parsed));
+    }
+    Ok(nlas)
+}

--- a/src/eeprom/get.rs
+++ b/src/eeprom/get.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+
+use futures::TryStream;
+use netlink_packet_generic::GenlMessage;
+
+use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};
+
+pub struct EthtoolModuleEEPROMGetRequest {
+    handle: EthtoolHandle,
+    iface_name: Option<String>,
+    offset: u32,
+    length: u32,
+    page: u8,
+    bank: u8,
+    i2c_address: u8,
+}
+
+impl EthtoolModuleEEPROMGetRequest {
+    pub(crate) fn new(handle: EthtoolHandle, iface_name: Option<&str>,
+            offset: u32,
+            length: u32,
+            page: u8,
+            bank: u8,
+            i2c_address: u8
+    ) -> Self {
+        EthtoolModuleEEPROMGetRequest {
+            handle,
+            iface_name: iface_name.map(|i| i.to_string()),
+            offset,
+            length,
+            page,
+            bank,
+            i2c_address
+        }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<EthtoolMessage>, Error = EthtoolError>
+    {
+        let EthtoolModuleEEPROMGetRequest {
+            mut handle,
+            iface_name,
+            offset,
+            length,
+            page,
+            bank,
+            i2c_address
+        } = self;
+
+        let ethtool_msg = EthtoolMessage::new_module_eeprom_get(iface_name.as_deref(), offset, length, page, bank, i2c_address);
+        ethtool_execute(&mut handle, iface_name.is_none(), ethtool_msg).await
+    }
+}

--- a/src/eeprom/handle.rs
+++ b/src/eeprom/handle.rs
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{EthtoolHandle, EthtoolModuleEEPROMGetRequest};
+
+pub struct EthtoolModuleEEPROMHandle(EthtoolHandle);
+
+impl EthtoolModuleEEPROMHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        EthtoolModuleEEPROMHandle(handle)
+    }
+
+    /// Retrieve the module eeprom data pages of a interface (used by `ethtool -m
+    /// eth1`)
+    pub fn get(&mut self, iface_name: Option<&str>,
+            offset: u32,
+            length: u32,
+            page: u8,
+            bank: u8,
+            i2c_address: u8
+    ) -> EthtoolModuleEEPROMGetRequest {
+        EthtoolModuleEEPROMGetRequest::new(self.0.clone(), iface_name, offset, length, page, bank, i2c_address)
+    }
+}

--- a/src/eeprom/mod.rs
+++ b/src/eeprom/mod.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+mod attr;
+mod get;
+mod handle;
+
+pub(crate) use attr::parse_module_eeprom_nlas;
+
+pub use attr::EthtoolModuleEEPROMAttr;
+pub use get::EthtoolModuleEEPROMGetRequest;
+pub use handle::EthtoolModuleEEPROMHandle;

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -9,9 +9,9 @@ use netlink_packet_core::{
 use netlink_packet_generic::GenlMessage;
 
 use crate::{
-    try_ethtool, EthtoolChannelHandle, EthtoolCoalesceHandle, EthtoolError,
-    EthtoolFeatureHandle, EthtoolFecHandle, EthtoolLinkModeHandle,
-    EthtoolMessage, EthtoolPauseHandle, EthtoolRingHandle, EthtoolTsInfoHandle,
+    try_ethtool, EthtoolChannelHandle, EthtoolCoalesceHandle, EthtoolError, EthtoolFeatureHandle,
+    EthtoolFecHandle, EthtoolLinkModeHandle, EthtoolMessage, EthtoolPauseHandle, EthtoolRingHandle,
+    EthtoolTsInfoHandle, EthtoolModuleEEPROMHandle
 };
 
 #[derive(Clone, Debug)]
@@ -54,6 +54,10 @@ impl EthtoolHandle {
 
     pub fn channel(&mut self) -> EthtoolChannelHandle {
         EthtoolChannelHandle::new(self.clone())
+    }
+
+    pub fn eeprom(&mut self) -> EthtoolModuleEEPROMHandle {
+        EthtoolModuleEEPROMHandle::new(self.clone())
     }
 
     pub async fn request(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod bitset_util;
 mod channel;
 mod coalesce;
 mod connection;
+mod eeprom;
 mod error;
 mod feature;
 mod fec;
@@ -30,6 +31,7 @@ pub use coalesce::{
 #[cfg(feature = "tokio_socket")]
 pub use connection::new_connection;
 pub use connection::new_connection_with_socket;
+pub use eeprom::{EthtoolModuleEEPROMAttr, EthtoolModuleEEPROMGetRequest, EthtoolModuleEEPROMHandle};
 pub use error::EthtoolError;
 pub use feature::{
     EthtoolFeatureAttr, EthtoolFeatureBit, EthtoolFeatureGetRequest,


### PR DESCRIPTION
Added support for the MODULE_EEPROM_GET netlink API to the crate following the pattern of the other commands

https://docs.kernel.org/networking/ethtool-netlink.html#module-eeprom-get