### PR TITLE
New release 0.2.9

### DIFF
--- a/.github/workflows/clippy-rustfmt.yml
+++ b/.github/workflows/clippy-rustfmt.yml
@@ -28,7 +28,9 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: clippy-tokio-socket
-        run: cargo clippy
+        run: cargo clippy -- -D warnings
 
       - name: clippy-smol-socket
-        run: cargo clippy --no-default-features --features smol_socket
+        run: >
+          cargo clippy --no-default-features
+          --features smol_socket -- -D warnings

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.2.9] - 2025-08-28
+### Breaking changes
+ - N/A
+
+### New features
+ - Support channel get/set. (c64872a)
+
+### Bug fixes
+ - Use latest rust-netlink crates. (39a1702)
+
 ## [0.2.8] - 2025-03-11
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ethtool"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Gris Ge <fge@redhat.com>"]
 license = "MIT"
 edition = "2021"


### PR DESCRIPTION
=== Breaking changes
- N/A

=== New features
- Support channel get/set. (c64872a)

=== Bug fixes
- Use latest rust-netlink crates. (39a1702)