### PR TITLE
Add Cable Test TDR Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,8 @@ thiserror = "1.0.69"
 tokio = { version = "1.44.0", features = ["rt"], optional = true}
 
 [dev-dependencies]
-tokio = { version = "1.44.0", features = ["macros", "rt", "rt-multi-thread"] }
+anyhow = "1.0.100"
+tokio = { version = "1.44.0", features = ["macros", "rt", "rt-multi-thread", "time"] }
 env_logger = "0.9.3"
 
 [[example]]

--- a/examples/cable_test_tdr.rs
+++ b/examples/cable_test_tdr.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+
+use anyhow::{Context, Result};
+use ethtool::{
+    EthtoolCableTestTdrConfig, EthtoolCmd, EthtoolError, EthtoolMessage,
+};
+use futures::{StreamExt, TryStreamExt};
+use netlink_packet_core::{
+    NetlinkMessage, NetlinkPayload, ParseableParametrized, NLM_F_REQUEST,
+};
+use netlink_packet_generic::{
+    ctrl::{
+        nlas::{GenlCtrlAttrs, McastGrpAttrs},
+        GenlCtrl, GenlCtrlCmd,
+    },
+    GenlFamily, GenlMessage,
+};
+use netlink_sys::AsyncSocket;
+use std::env;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 2 {
+        usage();
+        return Ok(());
+    }
+    let link_name = &args[1];
+    cable_test_tdr(link_name).await
+}
+
+async fn cable_test_tdr(iface_name: &str) -> Result<()> {
+    // Obtain the multicast group ID for "monitor".
+    let multicast_id = get_multicast_id().await?;
+    println!("Found Monitor Multicast Group with ID: {multicast_id}");
+
+    // Set up a new ethtool netlink connection and subscribe to the multicast
+    // group.
+    let (mut connection, mut handle, mut messages) = ethtool::new_connection()?;
+    {
+        let socket = connection.socket_mut().socket_mut();
+        socket.bind_auto()?;
+        socket.add_membership(multicast_id)?;
+    }
+
+    // Spawn the connection.
+    tokio::spawn(connection);
+
+    // Start the cable test.
+    let iface = iface_name.to_string();
+    tokio::spawn(async move {
+        let config = EthtoolCableTestTdrConfig {
+            first: Some(500),
+            last: None,
+            step: Some(200),
+            pair: None,
+        };
+
+        let mut stream = handle
+            .cable_test_tdr()
+            .start_with_config(&iface, config)
+            .execute()
+            .await;
+        match stream.try_next().await {
+            Ok(_) => println!(
+                "Started Cable Test TDR. This might take a few seconds."
+            ),
+            Err(e) => {
+                print_ethtool_error(e);
+                std::process::exit(1);
+            }
+        }
+    });
+
+    // Process incoming netlink messages, filtering for cable test
+    // notifications.
+    while let Some((msg, _)) = messages.next().await {
+        if let NetlinkPayload::InnerMessage(inner) = &msg.payload {
+            let ethtool_msg =
+                EthtoolMessage::parse_with_param(&inner.payload, inner.header)?;
+            if ethtool_msg.cmd == EthtoolCmd::CableTestTdrNotify {
+                dbg!(ethtool_msg);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn print_ethtool_error(error: EthtoolError) {
+    match error {
+        EthtoolError::NetlinkError(message) => {
+            if let Some(code) = message.code {
+                let os_error = std::io::Error::from_raw_os_error(-code.get());
+                eprintln!(
+                    "Netlink error occurred: OS error code: {}",
+                    os_error
+                );
+            } else {
+                eprintln!("Netlink error occurred: Unknown error code");
+            }
+        }
+        _ => eprintln!("Other error occurred: {error:?}"),
+    }
+}
+
+async fn get_multicast_id() -> Result<u32> {
+    let (connection, mut ethtool, _) = ethtool::new_connection()?;
+    let _ = tokio::spawn(connection);
+
+    // Build netlink control message.
+    let mut msg: NetlinkMessage<_> = GenlMessage::from_payload(GenlCtrl {
+        cmd: GenlCtrlCmd::GetFamily,
+        nlas: vec![GenlCtrlAttrs::FamilyName(
+            EthtoolMessage::family_name().to_owned(),
+        )],
+    })
+    .into();
+
+    msg.header.message_type =
+        ethtool.handle.resolve_family_id::<EthtoolMessage>().await?;
+    msg.header.flags = NLM_F_REQUEST;
+
+    // Receive response from control message request.
+    let responses = ethtool.handle.request(msg).await?;
+
+    let monitor_id = responses.try_filter_map(async move |response| {
+        // Only care about generic messages with inner messages.
+        let NetlinkPayload::InnerMessage(gen) = &response.payload else {
+            return Ok(None);
+        };
+
+        // Check for ethtool family in the nals.
+        let has_ethtool_family = gen.payload.nlas.iter().any(|nla| {
+            matches!(nla, GenlCtrlAttrs::FamilyName(name) if name == EthtoolMessage::family_name())
+        });
+
+        // Only care about NewFamily announcements.
+        if !has_ethtool_family || gen.payload.cmd != GenlCtrlCmd::NewFamily {
+            return Ok(None);
+        }
+
+        // Extract id on groups where name is "monitor".
+        let id = gen.payload.nlas.iter().find_map(|nla| {
+            let GenlCtrlAttrs::McastGroups(groups) = nla else {
+                return None;
+            };
+
+            groups.iter().find_map(|group| {
+                let mut id: Option<u32> = None;
+                let mut name: Option<&str> = None;
+
+                for a in group {
+                    match a {
+                        McastGrpAttrs::Id(v) => id = Some(*v),
+                        McastGrpAttrs::Name(n) => name = Some(n.as_str()),
+                    }
+                }
+
+                (name == Some("monitor")).then_some(id?)
+            })
+        });
+
+        Ok(id)
+    })
+    .try_collect::<Vec<_>>()
+    .await?
+    .into_iter()
+    .next()
+    .context("ethtool multicast monitor id not found")?;
+
+    Ok(monitor_id)
+}
+
+fn usage() {
+    eprintln!(
+        "Usage:
+    cargo run --example cable_test_tdr -- <link_name>
+
+Note: This program requires root privileges. It is recommended to build the example first:
+
+    cd ethtool
+    cargo build --example cable_test_tdr
+
+Then run the binary with sudo:
+
+    cd target/debug/examples
+    sudo ./cable_test_tdr <link_name>"
+    );
+}

--- a/src/cable_pair.rs
+++ b/src/cable_pair.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+
+const ETHTOOL_A_CABLE_PAIR_A: u8 = 0;
+const ETHTOOL_A_CABLE_PAIR_B: u8 = 1;
+const ETHTOOL_A_CABLE_PAIR_C: u8 = 2;
+const ETHTOOL_A_CABLE_PAIR_D: u8 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum EthtoolCablePair {
+    A,
+    B,
+    C,
+    D,
+    Other(u8),
+}
+
+impl From<u8> for EthtoolCablePair {
+    fn from(value: u8) -> Self {
+        match value {
+            ETHTOOL_A_CABLE_PAIR_A => Self::A,
+            ETHTOOL_A_CABLE_PAIR_B => Self::B,
+            ETHTOOL_A_CABLE_PAIR_C => Self::C,
+            ETHTOOL_A_CABLE_PAIR_D => Self::D,
+            _ => Self::Other(value),
+        }
+    }
+}
+
+impl From<EthtoolCablePair> for u8 {
+    fn from(value: EthtoolCablePair) -> Self {
+        match value {
+            EthtoolCablePair::A => ETHTOOL_A_CABLE_PAIR_A,
+            EthtoolCablePair::B => ETHTOOL_A_CABLE_PAIR_B,
+            EthtoolCablePair::C => ETHTOOL_A_CABLE_PAIR_C,
+            EthtoolCablePair::D => ETHTOOL_A_CABLE_PAIR_D,
+            EthtoolCablePair::Other(v) => v,
+        }
+    }
+}

--- a/src/cable_test_tdr/action.rs
+++ b/src/cable_test_tdr/action.rs
@@ -57,7 +57,7 @@ impl EthtoolCableTestTdrActionRequest {
         } = self;
 
         let ethtool_msg =
-            EthtoolMessage::new_cable_test_tdr(&iface_name, config);
+            EthtoolMessage::new_cable_test_tdr_action(&iface_name, config);
         let mut nl_msg =
             NetlinkMessage::from(GenlMessage::from_payload(ethtool_msg));
 

--- a/src/cable_test_tdr/action.rs
+++ b/src/cable_test_tdr/action.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+
+use futures::{future::Either, FutureExt, StreamExt, TryStream};
+use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
+use netlink_packet_generic::GenlMessage;
+
+use crate::{
+    try_ethtool, EthtoolCablePair, EthtoolError, EthtoolHandle, EthtoolMessage,
+};
+
+/// Configuration for a TDR (Time Domain Reflectometry) cable test.
+/// The ETHTOOL_A_CABLE_TEST_TDR_CFG is optional, as well as all members of the
+/// nest. All distances are expressed in centimeters. The PHY takes the
+/// distances as a guide, and rounds to the nearest distance it actually
+/// supports.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct EthtoolCableTestTdrConfig {
+    /// The first measurement point in centimeters.
+    pub first: Option<u32>,
+    /// The last measurement point in centimeters.
+    pub last: Option<u32>,
+    /// The step size between measurement points in centimeters.
+    pub step: Option<u32>,
+    /// The cable pair to test.
+    /// If a pair is passed, only that one pair will be tested. Otherwise all
+    /// pairs are tested.
+    pub pair: Option<EthtoolCablePair>,
+}
+
+pub struct EthtoolCableTestTdrActionRequest {
+    handle: EthtoolHandle,
+    iface_name: String,
+    config: Option<EthtoolCableTestTdrConfig>,
+}
+
+impl EthtoolCableTestTdrActionRequest {
+    pub(crate) fn new(
+        handle: EthtoolHandle,
+        iface_name: &str,
+        config: Option<EthtoolCableTestTdrConfig>,
+    ) -> Self {
+        EthtoolCableTestTdrActionRequest {
+            handle,
+            iface_name: iface_name.to_string(),
+            config,
+        }
+    }
+
+    pub async fn execute(
+        self,
+    ) -> impl TryStream<Ok = GenlMessage<EthtoolMessage>, Error = EthtoolError>
+    {
+        let EthtoolCableTestTdrActionRequest {
+            mut handle,
+            iface_name,
+            config,
+        } = self;
+
+        let ethtool_msg =
+            EthtoolMessage::new_cable_test_tdr(&iface_name, config);
+        let mut nl_msg =
+            NetlinkMessage::from(GenlMessage::from_payload(ethtool_msg));
+
+        // Use NLM_F_ACK because there is no REPLY for
+        // ETHTOOL_MSG_CABLE_TEST_TDR_ACT.
+        nl_msg.header.flags = NLM_F_REQUEST | NLM_F_ACK;
+
+        match handle.request(nl_msg).await {
+            Ok(response) => {
+                Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
+            }
+            Err(e) => {
+                Either::Right(
+                    futures::future::err::<
+                        GenlMessage<EthtoolMessage>,
+                        EthtoolError,
+                    >(e)
+                    .into_stream(),
+                )
+            }
+        }
+    }
+}

--- a/src/cable_test_tdr/attr/action.rs
+++ b/src/cable_test_tdr/attr/action.rs
@@ -6,8 +6,7 @@ use netlink_packet_core::{
 };
 
 use crate::{
-    cable_test_tdr::attr::config::EthtoolCableTestTdrConfigAttr, EthtoolAttr,
-    EthtoolHeader,
+    cable_test_tdr::attr::config::EthtoolCableTestTdrConfigAttr, EthtoolHeader,
 };
 
 const ETHTOOL_A_CABLE_TEST_TDR_HEADER: u16 = 1;
@@ -78,18 +77,4 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
             }
         }
     }
-}
-
-pub(crate) fn parse_cable_test_tdr_action_nlas(
-    buffer: &[u8],
-) -> Result<Vec<EthtoolAttr>, DecodeError> {
-    NlasIterator::new(buffer)
-        .map(|nla| {
-            let nla =
-                nla.context("failed to get ethtool cable test TDR action NLA")?;
-            let parsed = EthtoolCableTestTdrActionAttr::parse(&nla)
-                .context("failed to parse ethtool cable test TDR action NLA")?;
-            Ok(EthtoolAttr::CableTestTdrAction(parsed))
-        })
-        .collect()
 }

--- a/src/cable_test_tdr/attr/action.rs
+++ b/src/cable_test_tdr/attr/action.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    NlasIterator, Parseable, NLA_F_NESTED,
+};
+
+use crate::{
+    cable_test_tdr::attr::config::EthtoolCableTestTdrConfigAttr, EthtoolAttr,
+    EthtoolHeader,
+};
+
+const ETHTOOL_A_CABLE_TEST_TDR_HEADER: u16 = 1;
+const ETHTOOL_A_CABLE_TEST_TDR_CFG: u16 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrActionAttr {
+    Header(Vec<EthtoolHeader>),
+    Config(Vec<EthtoolCableTestTdrConfigAttr>),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrActionAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(header) => header.as_slice().buffer_len(),
+            Self::Config(config) => config.as_slice().buffer_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => ETHTOOL_A_CABLE_TEST_TDR_HEADER | NLA_F_NESTED,
+            Self::Config(_) => ETHTOOL_A_CABLE_TEST_TDR_CFG | NLA_F_NESTED,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(header) => header.as_slice().emit(buffer),
+            Self::Config(config) => config.as_slice().emit(buffer),
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrActionAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() {
+            ETHTOOL_A_CABLE_TEST_TDR_HEADER => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolHeader::parse(&nla?).context(
+                            "failed to parse ETHTOOL_A_CABLE_TEST_TDR_HEADER",
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Header(nlas))
+            }
+            ETHTOOL_A_CABLE_TEST_TDR_CFG => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolCableTestTdrConfigAttr::parse(&nla?).context(
+                            "failed to parse ETHTOOL_A_CABLE_TEST_TDR_CFG",
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Config(nlas))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR action")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}
+
+pub(crate) fn parse_cable_test_tdr_action_nlas(
+    buffer: &[u8],
+) -> Result<Vec<EthtoolAttr>, DecodeError> {
+    NlasIterator::new(buffer)
+        .map(|nla| {
+            let nla =
+                nla.context("failed to get ethtool cable test TDR action NLA")?;
+            let parsed = EthtoolCableTestTdrActionAttr::parse(&nla)
+                .context("failed to parse ethtool cable test TDR action NLA")?;
+            Ok(EthtoolAttr::CableTestTdrAction(parsed))
+        })
+        .collect()
+}

--- a/src/cable_test_tdr/attr/amplitude.rs
+++ b/src/cable_test_tdr/attr/amplitude.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    emit_i16, parse_i16, parse_u8, DecodeError, DefaultNla, Emitable,
+    ErrorContext, Nla, NlaBuffer, Parseable,
+};
+
+use crate::EthtoolCablePair;
+
+const ETHTOOL_A_CABLE_AMPLITUDE_PAIR: u16 = 1;
+const ETHTOOL_A_CABLE_AMPLITUDE_MV: u16 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrAmplitudeAttr {
+    Pair(EthtoolCablePair),
+    Mv(i16),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrAmplitudeAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Pair(_) => std::mem::size_of::<u8>(),
+            Self::Mv(_) => std::mem::size_of::<i16>(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Pair(_) => ETHTOOL_A_CABLE_AMPLITUDE_PAIR,
+            Self::Mv(_) => ETHTOOL_A_CABLE_AMPLITUDE_MV,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Pair(pair) => {
+                buffer.get_mut(0).map(|b| *b = (*pair).into()).unwrap()
+            }
+            Self::Mv(mv) => emit_i16(buffer, *mv).unwrap(),
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrAmplitudeAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() {
+            ETHTOOL_A_CABLE_AMPLITUDE_PAIR => {
+                let value = parse_u8(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_AMPLITUDE_PAIR",
+                )?;
+                Ok(Self::Pair(value.into()))
+            }
+            ETHTOOL_A_CABLE_AMPLITUDE_MV => {
+                let value = parse_i16(buf.value())
+                    .context("failed to parse ETHTOOL_A_CABLE_AMPLITUDE_MV")?;
+                Ok(Self::Mv(value))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR amplitude")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}

--- a/src/cable_test_tdr/attr/amplitude.rs
+++ b/src/cable_test_tdr/attr/amplitude.rs
@@ -36,9 +36,7 @@ impl Nla for EthtoolCableTestTdrAmplitudeAttr {
 
     fn emit_value(&self, buffer: &mut [u8]) {
         match self {
-            Self::Pair(pair) => {
-                buffer.get_mut(0).map(|b| *b = (*pair).into()).unwrap()
-            }
+            Self::Pair(pair) => buffer[0] = (*pair).into(),
             Self::Mv(mv) => emit_i16(buffer, *mv).unwrap(),
             Self::Other(attr) => attr.emit(buffer),
         }

--- a/src/cable_test_tdr/attr/config.rs
+++ b/src/cable_test_tdr/attr/config.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    emit_u32, parse_u32, parse_u8, DecodeError, DefaultNla, Emitable,
+    ErrorContext, Nla, NlaBuffer, Parseable,
+};
+
+use crate::EthtoolCablePair;
+
+const ETHTOOL_A_CABLE_TEST_TDR_CFG_FIRST: u16 = 1;
+const ETHTOOL_A_CABLE_TEST_TDR_CFG_LAST: u16 = 2;
+const ETHTOOL_A_CABLE_TEST_TDR_CFG_STEP: u16 = 3;
+const ETHTOOL_A_CABLE_TEST_TDR_CFG_PAIR: u16 = 4;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrConfigAttr {
+    First(u32),
+    Last(u32),
+    Step(u32),
+    Pair(EthtoolCablePair),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrConfigAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::First(_) | Self::Last(_) | Self::Step(_) => {
+                std::mem::size_of::<u32>()
+            }
+            Self::Pair(_) => std::mem::size_of::<u8>(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::First(_) => ETHTOOL_A_CABLE_TEST_TDR_CFG_FIRST,
+            Self::Last(_) => ETHTOOL_A_CABLE_TEST_TDR_CFG_LAST,
+            Self::Step(_) => ETHTOOL_A_CABLE_TEST_TDR_CFG_STEP,
+            Self::Pair(_) => ETHTOOL_A_CABLE_TEST_TDR_CFG_PAIR,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::First(first) => emit_u32(buffer, *first).unwrap(),
+            Self::Last(last) => emit_u32(buffer, *last).unwrap(),
+            Self::Step(step) => emit_u32(buffer, *step).unwrap(),
+            Self::Pair(pair) => {
+                buffer.get_mut(0).map(|b| *b = (*pair).into()).unwrap()
+            }
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrConfigAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() {
+            ETHTOOL_A_CABLE_TEST_TDR_CFG_FIRST => {
+                let value = parse_u32(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_TEST_TDR_CFG_FIRST",
+                )?;
+                Ok(Self::First(value))
+            }
+            ETHTOOL_A_CABLE_TEST_TDR_CFG_LAST => {
+                let value = parse_u32(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_TEST_TDR_CFG_LAST",
+                )?;
+                Ok(Self::Last(value))
+            }
+            ETHTOOL_A_CABLE_TEST_TDR_CFG_STEP => {
+                let value = parse_u32(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_TEST_TDR_CFG_STEP",
+                )?;
+                Ok(Self::Step(value))
+            }
+            ETHTOOL_A_CABLE_TEST_TDR_CFG_PAIR => {
+                let value = parse_u8(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_TEST_TDR_CFG_PAIR",
+                )?;
+                Ok(Self::Pair(value.into()))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR config")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}

--- a/src/cable_test_tdr/attr/config.rs
+++ b/src/cable_test_tdr/attr/config.rs
@@ -47,9 +47,7 @@ impl Nla for EthtoolCableTestTdrConfigAttr {
             Self::First(first) => emit_u32(buffer, *first).unwrap(),
             Self::Last(last) => emit_u32(buffer, *last).unwrap(),
             Self::Step(step) => emit_u32(buffer, *step).unwrap(),
-            Self::Pair(pair) => {
-                buffer.get_mut(0).map(|b| *b = (*pair).into()).unwrap()
-            }
+            Self::Pair(pair) => buffer[0] = (*pair).into(),
             Self::Other(attr) => attr.emit(buffer),
         }
     }

--- a/src/cable_test_tdr/attr/mod.rs
+++ b/src/cable_test_tdr/attr/mod.rs
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+mod action;
+mod amplitude;
+mod config;
+mod nest;
+mod notify;
+mod pulse;
+mod step;
+
+pub(crate) use action::parse_cable_test_tdr_action_nlas;
+pub(crate) use notify::parse_cable_test_tdr_notify_nlas;
+
+pub use action::EthtoolCableTestTdrActionAttr;
+pub use amplitude::EthtoolCableTestTdrAmplitudeAttr;
+pub use config::EthtoolCableTestTdrConfigAttr;
+pub use nest::EthtoolCableTestTdrNestAttr;
+pub use notify::{EthtoolCableTestTdrNotifyAttr, EthtoolCableTestTdrStatus};
+pub use pulse::EthtoolCableTestTdrPulseAttr;
+pub use step::EthtoolCableTestTdrStepAttr;

--- a/src/cable_test_tdr/attr/mod.rs
+++ b/src/cable_test_tdr/attr/mod.rs
@@ -8,7 +8,6 @@ mod notify;
 mod pulse;
 mod step;
 
-pub(crate) use action::parse_cable_test_tdr_action_nlas;
 pub(crate) use notify::parse_cable_test_tdr_notify_nlas;
 
 pub use action::EthtoolCableTestTdrActionAttr;

--- a/src/cable_test_tdr/attr/nest.rs
+++ b/src/cable_test_tdr/attr/nest.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    NlasIterator, Parseable, NLA_F_NESTED,
+};
+
+use crate::cable_test_tdr::attr::{
+    amplitude::EthtoolCableTestTdrAmplitudeAttr,
+    pulse::EthtoolCableTestTdrPulseAttr, step::EthtoolCableTestTdrStepAttr,
+};
+
+const ETHTOOL_A_CABLE_TDR_NEST_STEP: u16 = 1;
+const ETHTOOL_A_CABLE_TDR_NEST_AMPLITUDE: u16 = 2;
+const ETHTOOL_A_CABLE_TDR_NEST_PULSE: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrNestAttr {
+    Step(Vec<EthtoolCableTestTdrStepAttr>),
+    Amplitude(Vec<EthtoolCableTestTdrAmplitudeAttr>),
+    Pulse(Vec<EthtoolCableTestTdrPulseAttr>),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrNestAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Step(step) => step.as_slice().buffer_len(),
+            Self::Amplitude(amplitude) => amplitude.as_slice().buffer_len(),
+            Self::Pulse(pulse) => pulse.as_slice().buffer_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Step(_) => ETHTOOL_A_CABLE_TDR_NEST_STEP | NLA_F_NESTED,
+            Self::Amplitude(_) => {
+                ETHTOOL_A_CABLE_TDR_NEST_AMPLITUDE | NLA_F_NESTED
+            }
+            Self::Pulse(_) => ETHTOOL_A_CABLE_TDR_NEST_PULSE | NLA_F_NESTED,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Step(step) => step.as_slice().emit(buffer),
+            Self::Amplitude(amplitude) => amplitude.as_slice().emit(buffer),
+            Self::Pulse(pulse) => pulse.as_slice().emit(buffer),
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrNestAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() & !NLA_F_NESTED {
+            ETHTOOL_A_CABLE_TDR_NEST_STEP => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolCableTestTdrStepAttr::parse(&nla?).context(
+                            "failed to parse ETHTOOL_A_CABLE_TDR_NEST_STEP",
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Step(nlas))
+            }
+            ETHTOOL_A_CABLE_TDR_NEST_AMPLITUDE => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolCableTestTdrAmplitudeAttr::parse(&nla?)
+                            .context("failed to parse ETHTOOL_A_CABLE_TDR_NEST_AMPLITUDE")
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Amplitude(nlas))
+            }
+            ETHTOOL_A_CABLE_TDR_NEST_PULSE => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolCableTestTdrPulseAttr::parse(&nla?).context(
+                            "failed to parse ETHTOOL_A_CABLE_TDR_NEST_PULSE",
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Pulse(nlas))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR nest")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}

--- a/src/cable_test_tdr/attr/notify.rs
+++ b/src/cable_test_tdr/attr/notify.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    parse_u8, DecodeError, DefaultNla, Emitable, ErrorContext, Nla, NlaBuffer,
+    NlasIterator, Parseable, NLA_F_NESTED,
+};
+
+use crate::{
+    cable_test_tdr::attr::nest::EthtoolCableTestTdrNestAttr, EthtoolAttr,
+    EthtoolHeader,
+};
+
+const ETHTOOL_A_CABLE_TEST_TDR_NTF_HEADER: u16 = 1;
+const ETHTOOL_A_CABLE_TEST_TDR_NTF_STATUS: u16 = 2;
+const ETHTOOL_A_CABLE_TEST_TDR_NTF_NEST: u16 = 3;
+
+const ETHTOOL_A_CABLE_TEST_NTF_STATUS_STARTED: u8 = 1;
+const ETHTOOL_A_CABLE_TEST_NTF_STATUS_COMPLETED: u8 = 2;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum EthtoolCableTestTdrStatus {
+    Started,
+    Completed,
+    Other(u8),
+}
+
+impl From<u8> for EthtoolCableTestTdrStatus {
+    fn from(value: u8) -> Self {
+        match value {
+            ETHTOOL_A_CABLE_TEST_NTF_STATUS_STARTED => Self::Started,
+            ETHTOOL_A_CABLE_TEST_NTF_STATUS_COMPLETED => Self::Completed,
+            _ => Self::Other(value),
+        }
+    }
+}
+
+impl From<EthtoolCableTestTdrStatus> for u8 {
+    fn from(value: EthtoolCableTestTdrStatus) -> Self {
+        match value {
+            EthtoolCableTestTdrStatus::Started => {
+                ETHTOOL_A_CABLE_TEST_NTF_STATUS_STARTED
+            }
+            EthtoolCableTestTdrStatus::Completed => {
+                ETHTOOL_A_CABLE_TEST_NTF_STATUS_COMPLETED
+            }
+            EthtoolCableTestTdrStatus::Other(value) => value,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrNotifyAttr {
+    Header(Vec<EthtoolHeader>),
+    Status(EthtoolCableTestTdrStatus),
+    Nest(Vec<EthtoolCableTestTdrNestAttr>),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrNotifyAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Header(header) => header.as_slice().buffer_len(),
+            Self::Status(_) => std::mem::size_of::<u8>(),
+            Self::Nest(nest) => nest.as_slice().buffer_len(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Header(_) => {
+                ETHTOOL_A_CABLE_TEST_TDR_NTF_HEADER | NLA_F_NESTED
+            }
+            Self::Status(_) => ETHTOOL_A_CABLE_TEST_TDR_NTF_STATUS,
+            Self::Nest(_) => ETHTOOL_A_CABLE_TEST_TDR_NTF_NEST | NLA_F_NESTED,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Header(header) => header.as_slice().emit(buffer),
+            Self::Status(status) => {
+                buffer.get_mut(0).map(|b| *b = (*status).into()).unwrap()
+            }
+            Self::Nest(nest) => nest.as_slice().emit(buffer),
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrNotifyAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() {
+            ETHTOOL_A_CABLE_TEST_TDR_NTF_HEADER => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolHeader::parse(&nla?)
+                            .context("failed to parse ETHTOOL_A_CABLE_TEST_TDR_NTF_HEADER")
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Header(nlas))
+            }
+            ETHTOOL_A_CABLE_TEST_TDR_NTF_STATUS => {
+                let value = parse_u8(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_TEST_TDR_NTF_STATUS",
+                )?;
+                Ok(Self::Status(value.into()))
+            }
+            ETHTOOL_A_CABLE_TEST_TDR_NTF_NEST => {
+                let nlas = NlasIterator::new(buf.value())
+                    .map(|nla| {
+                        EthtoolCableTestTdrNestAttr::parse(&nla?).context(
+                            "failed to parse ETHTOOL_A_CABLE_TEST_TDR_NTF_NEST",
+                        )
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Self::Nest(nlas))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR notify")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}
+
+pub(crate) fn parse_cable_test_tdr_notify_nlas(
+    buffer: &[u8],
+) -> Result<Vec<EthtoolAttr>, DecodeError> {
+    NlasIterator::new(buffer)
+        .map(|nla| {
+            let nla = nla.context(
+                "failed to get ethtool cable test message attribute",
+            )?;
+            let parsed = EthtoolCableTestTdrNotifyAttr::parse(&nla)
+                .context("failed to parse ethtool cable test TDR NLA")?;
+            Ok(EthtoolAttr::CableTestTdrNotify(parsed))
+        })
+        .collect()
+}

--- a/src/cable_test_tdr/attr/notify.rs
+++ b/src/cable_test_tdr/attr/notify.rs
@@ -80,9 +80,7 @@ impl Nla for EthtoolCableTestTdrNotifyAttr {
     fn emit_value(&self, buffer: &mut [u8]) {
         match self {
             Self::Header(header) => header.as_slice().emit(buffer),
-            Self::Status(status) => {
-                buffer.get_mut(0).map(|b| *b = (*status).into()).unwrap()
-            }
+            Self::Status(status) => buffer[0] = (*status).into(),
             Self::Nest(nest) => nest.as_slice().emit(buffer),
             Self::Other(attr) => attr.emit(buffer),
         }

--- a/src/cable_test_tdr/attr/pulse.rs
+++ b/src/cable_test_tdr/attr/pulse.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    emit_i16, parse_i16, DecodeError, DefaultNla, Emitable, ErrorContext, Nla,
+    NlaBuffer, Parseable,
+};
+
+const ETHTOOL_A_CABLE_PULSE_MV: u16 = 1;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrPulseAttr {
+    Mv(i16),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrPulseAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::Mv(_) => std::mem::size_of::<i16>(),
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::Mv(_) => ETHTOOL_A_CABLE_PULSE_MV,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::Mv(mv) => emit_i16(buffer, *mv).unwrap(),
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrPulseAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() {
+            ETHTOOL_A_CABLE_PULSE_MV => {
+                let value = parse_i16(buf.value())
+                    .context("failed to parse ETHTOOL_A_CABLE_PULSE_MV")?;
+                Ok(Self::Mv(value))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR pulse")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}

--- a/src/cable_test_tdr/attr/step.rs
+++ b/src/cable_test_tdr/attr/step.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+use netlink_packet_core::{
+    emit_u32, parse_u32, DecodeError, DefaultNla, Emitable, ErrorContext, Nla,
+    NlaBuffer, Parseable,
+};
+
+const ETHTOOL_A_CABLE_STEP_FIRST_DISTANCE: u16 = 1;
+const ETHTOOL_A_CABLE_STEP_LAST_DISTANCE: u16 = 2;
+const ETHTOOL_A_CABLE_STEP_STEP_DISTANCE: u16 = 3;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EthtoolCableTestTdrStepAttr {
+    First(u32),
+    Last(u32),
+    Step(u32),
+    Other(DefaultNla),
+}
+
+impl Nla for EthtoolCableTestTdrStepAttr {
+    fn value_len(&self) -> usize {
+        match self {
+            Self::First(_) | Self::Last(_) | Self::Step(_) => {
+                std::mem::size_of::<u32>()
+            }
+            Self::Other(attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        match self {
+            Self::First(_) => ETHTOOL_A_CABLE_STEP_FIRST_DISTANCE,
+            Self::Last(_) => ETHTOOL_A_CABLE_STEP_LAST_DISTANCE,
+            Self::Step(_) => ETHTOOL_A_CABLE_STEP_STEP_DISTANCE,
+            Self::Other(attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        match self {
+            Self::First(value) | Self::Last(value) | Self::Step(value) => {
+                emit_u32(buffer, *value).unwrap()
+            }
+            Self::Other(attr) => attr.emit(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>>
+    for EthtoolCableTestTdrStepAttr
+{
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        match buf.kind() {
+            ETHTOOL_A_CABLE_STEP_FIRST_DISTANCE => {
+                let value = parse_u32(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_STEP_FIRST_DISTANCE",
+                )?;
+                Ok(Self::First(value))
+            }
+            ETHTOOL_A_CABLE_STEP_LAST_DISTANCE => {
+                let value = parse_u32(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_STEP_LAST_DISTANCE",
+                )?;
+                Ok(Self::Last(value))
+            }
+            ETHTOOL_A_CABLE_STEP_STEP_DISTANCE => {
+                let value = parse_u32(buf.value()).context(
+                    "failed to parse ETHTOOL_A_CABLE_STEP_STEP_DISTANCE",
+                )?;
+                Ok(Self::Step(value))
+            }
+            _ => {
+                let other = DefaultNla::parse(buf)
+                    .context("failed to parse unknown NLA for TDR step")?;
+                Ok(Self::Other(other))
+            }
+        }
+    }
+}

--- a/src/cable_test_tdr/handle.rs
+++ b/src/cable_test_tdr/handle.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+use crate::{
+    EthtoolCableTestTdrActionRequest, EthtoolCableTestTdrConfig, EthtoolHandle,
+};
+
+pub struct EthtoolCableTestTdrHandle(EthtoolHandle);
+
+impl EthtoolCableTestTdrHandle {
+    pub fn new(handle: EthtoolHandle) -> Self {
+        EthtoolCableTestTdrHandle(handle)
+    }
+
+    pub fn start(
+        &mut self,
+        iface_name: &str,
+    ) -> EthtoolCableTestTdrActionRequest {
+        EthtoolCableTestTdrActionRequest::new(self.0.clone(), iface_name, None)
+    }
+
+    pub fn start_with_config(
+        &mut self,
+        iface_name: &str,
+        config: EthtoolCableTestTdrConfig,
+    ) -> EthtoolCableTestTdrActionRequest {
+        EthtoolCableTestTdrActionRequest::new(
+            self.0.clone(),
+            iface_name,
+            Some(config),
+        )
+    }
+}

--- a/src/cable_test_tdr/mod.rs
+++ b/src/cable_test_tdr/mod.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+mod action;
+mod attr;
+mod handle;
+
+pub(crate) use attr::parse_cable_test_tdr_action_nlas;
+pub(crate) use attr::parse_cable_test_tdr_notify_nlas;
+
+pub use action::{EthtoolCableTestTdrActionRequest, EthtoolCableTestTdrConfig};
+pub use attr::{
+    EthtoolCableTestTdrActionAttr, EthtoolCableTestTdrAmplitudeAttr,
+    EthtoolCableTestTdrConfigAttr, EthtoolCableTestTdrNestAttr,
+    EthtoolCableTestTdrNotifyAttr, EthtoolCableTestTdrPulseAttr,
+    EthtoolCableTestTdrStatus, EthtoolCableTestTdrStepAttr,
+};
+pub use handle::EthtoolCableTestTdrHandle;

--- a/src/cable_test_tdr/mod.rs
+++ b/src/cable_test_tdr/mod.rs
@@ -4,7 +4,6 @@ mod action;
 mod attr;
 mod handle;
 
-pub(crate) use attr::parse_cable_test_tdr_action_nlas;
 pub(crate) use attr::parse_cable_test_tdr_notify_nlas;
 
 pub use action::{EthtoolCableTestTdrActionRequest, EthtoolCableTestTdrConfig};

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -9,9 +9,10 @@ use netlink_packet_core::{
 use netlink_packet_generic::GenlMessage;
 
 use crate::{
-    try_ethtool, EthtoolChannelHandle, EthtoolCoalesceHandle, EthtoolError,
-    EthtoolFeatureHandle, EthtoolFecHandle, EthtoolLinkModeHandle,
-    EthtoolMessage, EthtoolPauseHandle, EthtoolRingHandle, EthtoolTsInfoHandle,
+    try_ethtool, EthtoolCableTestTdrHandle, EthtoolChannelHandle,
+    EthtoolCoalesceHandle, EthtoolError, EthtoolFeatureHandle,
+    EthtoolFecHandle, EthtoolLinkModeHandle, EthtoolMessage,
+    EthtoolPauseHandle, EthtoolRingHandle, EthtoolTsInfoHandle,
 };
 
 #[derive(Clone, Debug)]
@@ -54,6 +55,10 @@ impl EthtoolHandle {
 
     pub fn channel(&mut self) -> EthtoolChannelHandle {
         EthtoolChannelHandle::new(self.clone())
+    }
+
+    pub fn cable_test_tdr(&mut self) -> EthtoolCableTestTdrHandle {
+        EthtoolCableTestTdrHandle::new(self.clone())
     }
 
     pub async fn request(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 mod bitset_util;
+mod cable_pair;
+mod cable_test_tdr;
 mod channel;
 mod coalesce;
 mod connection;
@@ -19,6 +21,15 @@ mod tsinfo;
 pub use self::fec::{
     EthtoolFecAttr, EthtoolFecGetRequest, EthtoolFecHandle, EthtoolFecMode,
     EthtoolFecStat,
+};
+pub use cable_pair::EthtoolCablePair;
+pub use cable_test_tdr::{
+    EthtoolCableTestTdrActionAttr, EthtoolCableTestTdrActionRequest,
+    EthtoolCableTestTdrAmplitudeAttr, EthtoolCableTestTdrConfig,
+    EthtoolCableTestTdrConfigAttr, EthtoolCableTestTdrHandle,
+    EthtoolCableTestTdrNestAttr, EthtoolCableTestTdrNotifyAttr,
+    EthtoolCableTestTdrPulseAttr, EthtoolCableTestTdrStatus,
+    EthtoolCableTestTdrStepAttr,
 };
 pub use channel::{
     EthtoolChannelAttr, EthtoolChannelGetRequest, EthtoolChannelHandle,

--- a/src/message.rs
+++ b/src/message.rs
@@ -4,9 +4,7 @@ use netlink_packet_core::{DecodeError, Emitable, Nla, ParseableParametrized};
 use netlink_packet_generic::{GenlFamily, GenlHeader};
 
 use crate::{
-    cable_test_tdr::{
-        parse_cable_test_tdr_action_nlas, parse_cable_test_tdr_notify_nlas,
-    },
+    cable_test_tdr::parse_cable_test_tdr_notify_nlas,
     channel::{parse_channel_nlas, EthtoolChannelAttr},
     coalesce::{parse_coalesce_nlas, EthtoolCoalesceAttr},
     feature::{parse_feature_nlas, EthtoolFeatureAttr},
@@ -312,7 +310,7 @@ impl EthtoolMessage {
         }
     }
 
-    pub fn new_cable_test_tdr(
+    pub fn new_cable_test_tdr_action(
         iface_name: &str,
         config: Option<EthtoolCableTestTdrConfig>,
     ) -> Self {
@@ -400,10 +398,6 @@ impl ParseableParametrized<[u8], GenlHeader> for EthtoolMessage {
             ETHTOOL_MSG_CHANNELS_GET_REPLY => Self {
                 cmd: EthtoolCmd::ChannelGetReply,
                 nlas: parse_channel_nlas(buffer)?,
-            },
-            ETHTOOL_MSG_CABLE_TEST_TDR_ACT => Self {
-                cmd: EthtoolCmd::CableTestTdrAction,
-                nlas: parse_cable_test_tdr_action_nlas(buffer)?,
             },
             ETHTOOL_MSG_CABLE_TEST_TDR_NTF => Self {
                 cmd: EthtoolCmd::CableTestTdrNotify,


### PR DESCRIPTION
This PR adds support for [Cable Test TDR](https://docs.kernel.org/networking/ethtool-netlink.html#linkmodes-get:~:text=Start%20a%20cable%20test%20and%20report%20raw%20TDR%20data).

- A TDR can be started by calling `start()` or `start_with_config(...)` on `EthtoolCableTestTdrHandle`.
- Results can be retrieved by listening to the `"monitor"` multicast group.
- Results are fully parsed.

<details>
<summary>Example output:</summary>
<pre>
Found Monitor Multicast Group with ID: 7
Started Cable Test TDR. This might take a few seconds.
[examples/cable_test_tdr.rs:82:17] ethtool_msg = EthtoolMessage {
    cmd: CableTestTdrNotify,
    nlas: [
        CableTestTdrNotify(
            Header(
                [
                    DevIndex(
                        3,
                    ),
                    DevName(
                        "enx787835110001",
                    ),
                ],
            ),
        ),
        CableTestTdrNotify(
            Status(
                Started,
            ),
        ),
    ],
}
[examples/cable_test_tdr.rs:82:17] ethtool_msg = EthtoolMessage {
    cmd: CableTestTdrNotify,
    nlas: [
        CableTestTdrNotify(
            Header(
                [
                    DevIndex(
                        3,
                    ),
                    DevName(
                        "enx787835110001",
                    ),
                ],
            ),
        ),
        CableTestTdrNotify(
            Status(
                Completed,
            ),
        ),
        CableTestTdrNotify(
            Nest(
                [
                    Pulse(
                        [
                            Mv(
                                1000,
                            ),
                        ],
                    ),
                    Step(
                        [
                            First(
                                483,
                            ),
                            Last(
                                14973,
                            ),
                            Step(
                                161,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                A,
                            ),
                            Mv(
                                31,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                B,
                            ),
                            Mv(
                                23,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                C,
                            ),
                            Mv(
                                15,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                D,
                            ),
                            Mv(
                                31,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                A,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                B,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                C,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                D,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                A,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                B,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    Amplitude(
                        [
                            Pair(
                                C,
                            ),
                            Mv(
                                -7,
                            ),
                        ],
                    ),
                    // ... rest removed for readability
    ],
}
</pre>
</details>