### PR TITLE
Cargo: Use `futures-util` and `futures-channel` to replace `futures` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ smol_socket = ["netlink-proto/smol_socket", "async-std"]
 
 [dependencies]
 async-std = { version = "1.13.0", optional = true}
-futures = "0.3.31"
+futures-util = "0.3.11"
+futures-channel = "0.3.11"
 log = "0.4.26"
 genetlink = { default-features = false, version = "0.2.6"}
 netlink-packet-core = { version = "0.8.0"}

--- a/examples/dump_channels.rs
+++ b/examples/dump_channels.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_coalesce.rs
+++ b/examples/dump_coalesce.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_eeprom_page.rs
+++ b/examples/dump_eeprom_page.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 fn main() {
     let rt = tokio::runtime::Builder::new_current_thread()

--- a/examples/dump_features.rs
+++ b/examples/dump_features.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_fec.rs
+++ b/examples/dump_fec.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_link_mode.rs
+++ b/examples/dump_link_mode.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_pause.rs
+++ b/examples/dump_pause.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_rings.rs
+++ b/examples/dump_rings.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/examples/dump_tsinfo.rs
+++ b/examples/dump_tsinfo.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 // Once we find a way to load netsimdev kernel module in CI, we can convert this
 // to a test

--- a/src/channel/get.rs
+++ b/src/channel/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/channel/set.rs
+++ b/src/channel/set.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_REQUEST};
 use netlink_packet_generic::GenlMessage;
 

--- a/src/coalesce/get.rs
+++ b/src/coalesce/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -2,7 +2,7 @@
 
 use std::io;
 
-use futures::channel::mpsc::UnboundedReceiver;
+use futures_channel::mpsc::UnboundedReceiver;
 use genetlink::message::RawGenlMessage;
 use netlink_packet_core::NetlinkMessage;
 use netlink_proto::Connection;

--- a/src/eeprom/get.rs
+++ b/src/eeprom/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/feature/get.rs
+++ b/src/feature/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/fec/get.rs
+++ b/src/fec/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::{future::Either, FutureExt, Stream, StreamExt, TryStream};
+use futures_util::{future::Either, FutureExt, Stream, StreamExt, TryStream};
 use genetlink::GenetlinkHandle;
 use netlink_packet_core::DecodeError;
 use netlink_packet_core::{
@@ -106,9 +106,10 @@ pub(crate) async fn ethtool_execute(
             Either::Left(response.map(move |msg| Ok(try_ethtool!(msg))))
         }
         Err(e) => Either::Right(
-            futures::future::err::<GenlMessage<EthtoolMessage>, EthtoolError>(
-                e,
-            )
+            futures_util::future::err::<
+                GenlMessage<EthtoolMessage>,
+                EthtoolError,
+            >(e)
             .into_stream(),
         ),
     }

--- a/src/link_mode/get.rs
+++ b/src/link_mode/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/pause/get.rs
+++ b/src/pause/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/ring/get.rs
+++ b/src/ring/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/src/tsinfo/get.rs
+++ b/src/tsinfo/get.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::TryStream;
+use futures_util::TryStream;
 use netlink_packet_generic::GenlMessage;
 
 use crate::{ethtool_execute, EthtoolError, EthtoolHandle, EthtoolMessage};

--- a/tests/dump_link_modes.rs
+++ b/tests/dump_link_modes.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 #[test]
 // CI container normally have a veth for external communication which support

--- a/tests/get_features_lo.rs
+++ b/tests/get_features_lo.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use futures::stream::TryStreamExt;
+use futures_util::stream::TryStreamExt;
 
 #[test]
 fn test_get_features_of_loopback() {


### PR DESCRIPTION
The `futures` crate contains more than we needs, this patch use
`futures-channel` and `futures-channel` instead.